### PR TITLE
Fix: Clean up temporary disk image files

### DIFF
--- a/src/agentmgr/cdrom_manager.go
+++ b/src/agentmgr/cdrom_manager.go
@@ -33,6 +33,7 @@ func (m cdromManager) Write(vmCID apiv1.VMCID, agentEnv apiv1.AgentEnv) ([]byte,
 	if err != nil {
 		return nil, err
 	}
+	defer os.Remove(cdromFileName)
 
 	var diskSize int64 = 5 * 1024 * 1024 // 5 MB
 	image, err := diskfs.Create(cdromFileName, diskSize, diskfs.SectorSizeDefault)

--- a/src/agentmgr/fat32_manager.go
+++ b/src/agentmgr/fat32_manager.go
@@ -38,6 +38,7 @@ func (c fat32Manager) Write(vmCID apiv1.VMCID, agentEnv apiv1.AgentEnv) ([]byte,
 	if err != nil {
 		return nil, err
 	}
+	defer os.Remove(diskFileName)
 
 	// Note that the sizes are rough guesstimates.
 	// diskSize = 35MB; minimum size is 32MB but...


### PR DESCRIPTION
## Problem
The FAT32 and CDROM managers were creating large temporary disk image files during VM agent configuration but never deleting them:
- FAT32 manager: 35MB temporary files
- CDROM manager: 5MB temporary files

This caused resource exhaustion over time, as each VM creation would leave orphaned files on disk indefinitely.

## Solution
Added `defer os.Remove()` cleanup calls in both managers to ensure temporary files are deleted after being read.

### Changes
- **src/agentmgr/fat32_manager.go**: Added defer cleanup for FAT32 disk image (line 40)
- **src/agentmgr/cdrom_manager.go**: Added defer cleanup for ISO image (line 36)

## Testing
The fix has been verified to:
- Properly clean up temporary files after VM creation
- Not affect the binary data returned to the caller
- Handle edge cases where temporary file creation fails (cleanup doesn't execute)

This resolves the resource leak issue and prevents disk space exhaustion in long-running BOSH deployments.