### PR TITLE
fix: add nil pointer check in FindExistingImage

### DIFF
--- a/src/adapter/incus/image.go
+++ b/src/adapter/incus/image.go
@@ -22,7 +22,9 @@ func (a *incusApiAdapter) FindExistingImage(description string) (string, error) 
 	}
 	for _, image := range images {
 		if description == image.Properties["description"] {
-			return image.Aliases[0].Name, nil
+			if len(image.Aliases) > 0 {
+				return image.Aliases[0].Name, nil
+			}
 		}
 	}
 	return "", nil

--- a/src/adapter/lxd/image.go
+++ b/src/adapter/lxd/image.go
@@ -22,7 +22,9 @@ func (a *lxdApiAdapter) FindExistingImage(description string) (string, error) {
 	}
 	for _, image := range images {
 		if description == image.Properties["description"] {
-			return image.Aliases[0].Name, nil
+			if len(image.Aliases) > 0 {
+				return image.Aliases[0].Name, nil
+			}
 		}
 	}
 	return "", nil


### PR DESCRIPTION
## Description
Fixes a critical nil pointer dereference bug in the `FindExistingImage` function that could cause a panic at runtime.

## Changes
- Added bounds check before accessing `image.Aliases[0].Name` in both LXD and Incus adapters
- Prevents panic when an image with matching description has no aliases

## Files Changed
- `src/adapter/lxd/image.go`
- `src/adapter/incus/image.go`

## Testing
The fix adds a safety check that gracefully skips images without aliases instead of panicking. This prevents a runtime crash when searching for images by description.

## Issue
This was identified as a critical bug that could cause the service to crash when enumerating images if any image with a matching description had no aliases defined.