### PR TITLE
fix: add missing wait() wrappers in Incus volume operations

### DIFF
--- a/src/adapter/incus/volume.go
+++ b/src/adapter/incus/volume.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (a *incusApiAdapter) DeleteStoragePoolVolume(pool, name string) error {
-	return a.client.DeleteStoragePoolVolume(pool, "custom", name)
+	return wait(a.client.DeleteStoragePoolVolume(pool, "custom", name))
 }
 
 func (a *incusApiAdapter) GetStoragePoolVolume(pool, name string) (string, error) {
@@ -26,7 +26,7 @@ func (a *incusApiAdapter) ResizeStoragePoolVolume(pool, name string, newSize int
 	writable := volume.Writable()
 	writable.Config["size"] = fmt.Sprintf("%dMiB", newSize)
 
-	return a.client.UpdateStoragePoolVolume(pool, "custom", name, writable, etag)
+	return wait(a.client.UpdateStoragePoolVolume(pool, "custom", name, writable, etag))
 }
 
 func (a *incusApiAdapter) CreateStoragePoolVolume(target, pool, name string, size int) error {
@@ -45,7 +45,7 @@ func (a *incusApiAdapter) CreateStoragePoolVolume(target, pool, name string, siz
 	if target != "" {
 		c = c.UseTarget(target)
 	}
-	return c.CreateStoragePoolVolume(pool, storageVolumeRequest)
+	return wait(c.CreateStoragePoolVolume(pool, storageVolumeRequest))
 }
 
 func (a *incusApiAdapter) CreateStoragePoolVolumeFromISO(target, pool, diskName string, backupFile io.Reader) error {
@@ -67,7 +67,7 @@ func (a *incusApiAdapter) UpdateStoragePoolVolumeDescription(pool, diskName, des
 
 	volume.Description = description
 
-	return a.client.UpdateStoragePoolVolume(pool, "custom", diskName, volume.Writable(), etag)
+	return wait(a.client.UpdateStoragePoolVolume(pool, "custom", diskName, volume.Writable(), etag))
 }
 func (a *incusApiAdapter) GetStoragePoolVolumeUsage(pool string) (map[string]int, error) {
 	volumes, err := a.client.GetStoragePoolVolumes(pool)
@@ -113,5 +113,5 @@ func (a *incusApiAdapter) ColocateStoragePoolVolumeWithInstance(instanceName, po
 		return err
 	}
 
-	return srcServer.DeleteStoragePoolVolume(pool, "custom", diskName)
+	return wait(srcServer.DeleteStoragePoolVolume(pool, "custom", diskName))
 }


### PR DESCRIPTION
## Description
Fixes missing `wait()` wrappers on async volume operations in the Incus adapter, ensuring consistency with the LXD adapter implementation.

## Problem
Several volume operations in the Incus adapter were missing `wait()` wrappers that properly handle async operations. This means operations could return before completion, causing potential race conditions and incomplete operations.

## Changes
Added `wait()` wrapper to async operations in `src/adapter/incus/volume.go`:
- `DeleteStoragePoolVolume` (line 12)
- `ResizeStoragePoolVolume` (line 29)
- `CreateStoragePoolVolume` (line 48)
- `UpdateStoragePoolVolumeDescription` (line 70)
- `ColocateStoragePoolVolumeWithInstance` - final DeleteStoragePoolVolume call (line 116)

## Impact
- Ensures async operations complete before returning
- Prevents race conditions and partial state
- Maintains consistency between LXD and Incus adapters
- No breaking changes to public API

## Testing
This aligns the Incus adapter's behavior with the LXD adapter, which already uses `wait()` correctly on these operations.