### PR TITLE
fix: add Description support in Incus snapshot creation

### DIFF
--- a/src/adapter/incus/snapshot.go
+++ b/src/adapter/incus/snapshot.go
@@ -12,5 +12,17 @@ func (a *incusApiAdapter) CreateStoragePoolVolumeSnapshot(pool, volumeName, snap
 	post := api.StorageVolumeSnapshotsPost{
 		Name: snapshotName,
 	}
-	return wait(a.client.CreateStoragePoolVolumeSnapshot(pool, "custom", volumeName, post))
+	err := wait(a.client.CreateStoragePoolVolumeSnapshot(pool, "custom", volumeName, post))
+	if err != nil {
+		return err
+	}
+
+	snapshot, etag, err := a.client.GetStoragePoolVolumeSnapshot(pool, "custom", volumeName, snapshotName)
+	if err != nil {
+		return err
+	}
+
+	// Update the snapshot with the description
+	snapshot.Description = description
+	return a.client.UpdateStoragePoolVolumeSnapshot(pool, "custom", volumeName, snapshotName, snapshot.Writable(), etag)
 }


### PR DESCRIPTION
## Description
Fixes the Incus adapter to properly set snapshot descriptions when creating storage pool volume snapshots.

## Problem
The `CreateStoragePoolVolumeSnapshot` function was accepting a `description` parameter but not using it. Unlike the LXD adapter, the Incus API doesn't support Description in the `StorageVolumeSnapshotsPost` struct during creation.

## Solution
The implementation now:
1. Creates the snapshot without description
2. Retrieves the newly created snapshot with its etag
3. Updates the snapshot to add the description

This ensures snapshot descriptions are properly preserved for Incus, matching the intended behavior.

## Files Changed
- `src/adapter/incus/snapshot.go`

## Testing
Code has been compiled and verified to work correctly.