### PR TITLE
fix: move defer os.Remove() after diskfs.Create() succeeds

### DIFF
--- a/src/agentmgr/cdrom_manager.go
+++ b/src/agentmgr/cdrom_manager.go
@@ -33,13 +33,13 @@ func (m cdromManager) Write(vmCID apiv1.VMCID, agentEnv apiv1.AgentEnv) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(cdromFileName)
 
 	var diskSize int64 = 5 * 1024 * 1024 // 5 MB
 	image, err := diskfs.Create(cdromFileName, diskSize, diskfs.SectorSizeDefault)
 	if err != nil {
 		return nil, err
 	}
+	defer os.Remove(cdromFileName)
 
 	image.LogicalBlocksize = 2048
 	fspec := disk.FilesystemSpec{

--- a/src/agentmgr/fat32_manager.go
+++ b/src/agentmgr/fat32_manager.go
@@ -38,7 +38,6 @@ func (c fat32Manager) Write(vmCID apiv1.VMCID, agentEnv apiv1.AgentEnv) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(diskFileName)
 
 	// Note that the sizes are rough guesstimates.
 	// diskSize = 35MB; minimum size is 32MB but...
@@ -50,6 +49,7 @@ func (c fat32Manager) Write(vmCID apiv1.VMCID, agentEnv apiv1.AgentEnv) ([]byte,
 	if err != nil {
 		return nil, err
 	}
+	defer os.Remove(diskFileName)
 
 	table := &mbr.Table{
 		LogicalSectorSize:  512,


### PR DESCRIPTION
## Description
Fixes the timing of cleanup deferred statements to ensure temporary disk files are only cleaned up after they are successfully created.

## Problem
The `defer os.Remove()` statements were placed before `diskfs.Create()` calls. If `diskfs.Create()` failed, the deferred cleanup would still execute, attempting to remove a file that may not exist. This could mask the original error and cause confusion.

## Solution
Move the `defer os.Remove()` statements to immediately after the successful `diskfs.Create()` calls. This ensures:
1. The file path actually exists when cleanup is attempted
2. We don't try to remove files that failed to create
3. Proper error handling when disk creation fails

## Files Changed
- `src/agentmgr/cdrom_manager.go` - ISO disk creation
- `src/agentmgr/fat32_manager.go` - FAT32 disk creation

## Impact
- Better error handling and clearer failure paths
- No cleanup attempts on failed disk creation
- Proper resource cleanup only when needed